### PR TITLE
Fix PATH to poetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ push:  ## Push docker image to
 	docker push ${DOCKER_NAMESPACE}/${IMAGE}:${TAG}
 
 run:  ## Run image locally
-	docker run -it -p ${HOST_PORT}:8888 ${IMAGE}:${TAG}
+	docker run -it -p ${HOST_PORT}:8888 ${IMAGE}:${TAG} ${CMD}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -241,10 +241,9 @@ RUN pip install --upgrade pip>=19.0
 
 # Install poetry
 # --------------
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python 
-RUN cat $HOME/.poetry/env
-RUN source $HOME/.poetry/env
-RUN $HOME/.poetry/bin/poetry config virtualenvs.create false
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+ENV PATH "$HOME/.poetry/bin:$PATH"
+RUN poetry config virtualenvs.create false
 
 # Install Pipenv
 # --------------


### PR DESCRIPTION
Updating `PATH` in `.bashrc` is not sufficient if `poetry` is used when building other images from this base, or indeed when running `poetry` as an entrypoint CMD without bash.

A better user-scoped way seems to be using `ENV` to update `PATH`